### PR TITLE
fix (ui): [Dark mode] Adapt centreon-single-metric widget to dark theme

### DIFF
--- a/single-metric/index.php
+++ b/single-metric/index.php
@@ -59,6 +59,11 @@ try {
     if ($autoRefresh === false || $autoRefresh < 5) {
         $autoRefresh = 30;
     }
+    $variablesThemeCSS = match ($centreon->user->theme) {
+        'light' => "Generic-theme",
+        'dark' => "Centreon-Dark",
+        default => throw new \Exception('Unknown user theme : ' . $centreon->user->theme),
+    };
 } catch (Exception $e) {
     echo $e->getMessage() . "<br/>";
     exit;
@@ -83,6 +88,13 @@ if (! $isAdmin) {
 $path = $centreon_path . "www/widgets/single-metric/src/";
 $template = new Smarty();
 $template = initSmartyTplForPopup($path, $template, "./", $centreon_path);
+$template->assign('theme', $variablesThemeCSS);
+$template->assign(
+    'webTheme',
+    $variablesThemeCSS === 'Generic-theme'
+        ? $variablesThemeCSS . '/Variables-css'
+        : $variablesThemeCSS
+);
 
 $data = array();
 

--- a/single-metric/src/Themes/Centreon-Dark/variables.css
+++ b/single-metric/src/Themes/Centreon-Dark/variables.css
@@ -1,0 +1,9 @@
+@import "../Generic-theme/variables.css";
+
+:root {
+    --metric-links-font-color: var(--color-cloudy);
+    --state-ok-font-color: var(--color-green);
+    --state-warning-font-color: var(--color-orange);
+    --state-critical-font-color: var(--color-red);
+    --metric-coloring-font-color: var(--color-white);
+}

--- a/single-metric/src/Themes/Generic-theme/color-variables.css
+++ b/single-metric/src/Themes/Generic-theme/color-variables.css
@@ -1,0 +1,9 @@
+:root {
+    --color-martar: #555;
+    --color-green: #84bd00;
+    --color-red: #f90026;
+    --color-orange: #ff9a13;
+    --color-black: #000;
+    --color-white: #fff;
+    --color-cloudy: #b2aca2;
+}

--- a/single-metric/src/Themes/Generic-theme/variables.css
+++ b/single-metric/src/Themes/Generic-theme/variables.css
@@ -1,0 +1,9 @@
+@import "color-variables.css";
+
+:root {
+    --metric-links-font-color: var(--color-martar);
+    --state-ok-font-color: var(--color-green);
+    --state-warning-font-color: var(--color-orange);
+    --state-critical-font-color: var(--color-red);
+    --metric-coloring-font-color: var(--color-black);
+}

--- a/single-metric/src/metric-display.css
+++ b/single-metric/src/metric-display.css
@@ -50,3 +50,23 @@
     text-align : center;
     line-height: 45px;
 }
+
+.metric-links a, span {
+    color: var(--metric-links-font-color);
+}
+
+.state-ok {
+    color: var(--state-ok-font-color);
+}
+
+.state-warning {
+    color: var(--state-warning-font-color);
+}
+
+.state-critical {
+    color: var(--state-critical-font-color);
+}
+
+.metric-coloring {
+    color: var(--metric-coloring-font-color);
+}

--- a/single-metric/src/metric.ihtml
+++ b/single-metric/src/metric.ihtml
@@ -1,15 +1,18 @@
 <html>
 <head>
     <title>single-metric</title>
-    <link href="../../Themes/Centreon-2/style.css" type="text/css"/>
-    <link href="../../Themes/Centreon-2/Color/blue_css.php" rel="stylesheet" text="text/css"/>
+    <link href="../../Themes/Generic-theme/style.css" type="text/css"/>
+    <link href="../../Themes/Generic-theme/color.css" rel="stylesheet" text="text/css"/>
+    <link href="src/metric-display.css" rel="stylesheet" text="text/css"/>
+    <link href="../../Themes/{$webTheme}/variables.css" rel="stylesheet" type="text/css"/>
+    <link href="src/Themes/{$theme}/variables.css" rel="stylesheet" type="text/css"/>
     {literal}
     <style type="text/css">
         .ListTable {font-size:11px;border-color: #BFD0E2;}
     </style>
     <style>
         @import url('src/single-metric.css');
-        @import url('../../Themes/Centreon-2/style.css');
+        @import url('../../Themes/Generic-theme/style.css');
     </style>
     {/literal}
 </head>
@@ -21,19 +24,19 @@
         <div id="metric" style="text-align:center;">
         {foreach item=elem from=$data}
           {if $preferences.display_path == true}
-            <span style="font-size:10pt;font-weight:bold;text-align:center;"><a style="font-size:10pt;font-weight:bold;color:black;" href='{$elem.host_uri}' target='_blank'>{$elem.host_name}</a> &gt; <a style="font-size:10pt;font-weight:bold;color:black;" href='{$elem.details_uri}' target='_blank'>{$elem.service_description}</a> &gt; <a style="font-size:10pt;font-weight:bold;color:black;" href='{$elem.graph_uri}' target='_blank'>{$elem.metric_name}</a></span><br/>
+              <span class="metric-links" style="font-size:10pt;font-weight:bold;text-align:center;"><a style="font-size:10pt;font-weight:bold" href='{$elem.host_uri}' target='_blank'>{$elem.host_name}</a><span> &gt; </span><a style="font-size:10pt;font-weight:bold;" href='{$elem.details_uri}' target='_blank'>{$elem.service_description}</a><span> &gt; </span><a style="font-size:10pt;font-weight:bold;" href='{$elem.graph_uri}' target='_blank'>{$elem.metric_name}</a></span><br/>
           {/if}
           {if $preferences.coloring == 'black'}
-             <span style="color: black;font-size:{$preferences.font_size}pt;">{$elem.value_displayed} {$elem.unit_displayed}</span>
+             <span class="metric-coloring" style="font-size:{$preferences.font_size}pt;">{$elem.value_displayed} {$elem.unit_displayed}</span>
           {else if $preferences.coloring == 's_state'}
             {if $elem.status == 0 }
-              <span style="color: #88b917;font-size:{$preferences.font_size}pt;">{$elem.value_displayed} {$elem.unit_displayed}</span>
+              <span class="state-ok" style="font-size:{$preferences.font_size}pt;">{$elem.value_displayed} {$elem.unit_displayed}</span>
             {/if}
             {if $elem.status == 1 }
-              <span style="color: #ff9a13;font-size:{$preferences.font_size}pt;">{$elem.value_displayed} {$elem.unit_displayed}</span>
+              <span class="state-warning" style="font-size:{$preferences.font_size}pt;">{$elem.value_displayed} {$elem.unit_displayed}</span>
             {/if}
             {if $elem.status == 2 }
-              <span style="color: #e00b3d;font-size:{$preferences.font_size}pt;">{$elem.value_displayed} {$elem.unit_displayed}</span>
+              <span class="state-critical" style="font-size:{$preferences.font_size}pt;">{$elem.value_displayed} {$elem.unit_displayed}</span>
             {/if}
             {if $elem.status == 3 }
               <span style="font-size:{$preferences.font_size}pt;">{$elem.value_displayed} {$elem.unit_displayed}</span>
@@ -42,27 +45,27 @@
             {if $elem.status == 3 }
               <span style="font-size:{$preferences.font_size}pt;">{$elem.value_displayed} {$elem.unit_displayed}</span>
             {else if $elem.critical !== null && $elem.current_float_value >= $elem.critical }
-              <span style="color: #e00b3d;font-size:{$preferences.font_size}pt;">{$elem.value_displayed} {$elem.unit_displayed}</span>
+              <span class="state-critical" style="font-size:{$preferences.font_size}pt;">{$elem.value_displayed} {$elem.unit_displayed}</span>
             {else if $elem.warning !== null && $elem.current_float_value >= $elem.warning }
-              <span style="color: #ff9a13;font-size:{$preferences.font_size}pt;">{$elem.value_displayed} {$elem.unit_displayed}</span>
+              <span class="state-warning" style="font-size:{$preferences.font_size}pt;">{$elem.value_displayed} {$elem.unit_displayed}</span>
             {else}
-              <span style="color: #88b917;font-size:{$preferences.font_size}pt;">{$elem.value_displayed} {$elem.unit_displayed}</span>
+              <span class="state-ok" style="font-size:{$preferences.font_size}pt;">{$elem.value_displayed} {$elem.unit_displayed}</span>
             {/if}
           {/if}
           <br/>
           {if $preferences.display_threshold == true}
             {if $elem.warning != "" }
               {if $preferences.coloring == 'black'}
-                <span style="font-size:{$preferences.threshold_font_size}pt;color: black;">Warning : {$elem.warning_displayed}{$elem.unit_displayed}</span><br/>
+                <span class="metric-coloring" style="font-size:{$preferences.threshold_font_size}pt;">Warning : {$elem.warning_displayed}{$elem.unit_displayed}</span><br/>
               {else}
-                <span style="font-size:{$preferences.threshold_font_size}pt;color: #ff9a13;">Warning : {$elem.warning_displayed}{$elem.unit_displayed}</span><br/>
+                <span class="state-warning" style="font-size:{$preferences.threshold_font_size}pt;">Warning : {$elem.warning_displayed}{$elem.unit_displayed}</span><br/>
               {/if}
             {/if}
             {if $elem.critical != "" }
               {if $preferences.coloring == 'black'}
-                <span style="font-size:{$preferences.threshold_font_size}pt;color: black;">Critical : {$elem.critical_displayed}{$elem.unit_displayed}</span><br/>
+                <span class="metric-coloring" style="font-size:{$preferences.threshold_font_size}pt;">Critical : {$elem.critical_displayed}{$elem.unit_displayed}</span><br/>
               {else}
-                <span style="font-size:{$preferences.threshold_font_size}pt;color: #e00b3d;">Critical : {$elem.critical_displayed}{$elem.unit_displayed}</span><br/>
+                <span class="state-critical" style="font-size:{$preferences.threshold_font_size}pt;">Critical : {$elem.critical_displayed}{$elem.unit_displayed}</span><br/>
               {/if}
             {/if}
           {/if}


### PR DESCRIPTION
# Pull Request Template

Adapt centreon-single-metric widget to dark theme and export all variables css

![image](https://user-images.githubusercontent.com/97593248/168985479-74f0a420-cc2a-4cc6-ac72-64080d56b3ee.png)

**Fixes** # MON-12782

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
